### PR TITLE
fix indent and codestyle

### DIFF
--- a/src/pages/Index.js
+++ b/src/pages/Index.js
@@ -21,12 +21,18 @@ const messages = defineMessages({
 class Index extends Component {
   render() {
     return (
-			<StyleRoot id="index">
+      <StyleRoot id="index">
         <Helmet title="Index" />
-        <div><FormattedMessage {...messages.welcomeMessage} /></div>
-				<Link to={ '/home' } ><Theme render="Button"><FormattedMessage { ...messages.takeMeHome } /></Theme></Link>
-			</StyleRoot>
-		);
+        <div>
+          <FormattedMessage { ...messages.welcomeMessage } />
+        </div>
+        <Link to={ '/home' }>
+          <Theme render="Button">
+            <FormattedMessage { ...messages.takeMeHome } />
+          </Theme>
+        </Link>
+      </StyleRoot>
+    );
   }
 }
 


### PR DESCRIPTION
Removed some tab characters and fixed spacing around props. 

I'd recommend just sticking to no spaces around prop values (`prop={something}`) as that's more common, even if objects outside of JSX have spaces. It's an exception – just like using double quotes in JSX.

Also I noticed elsewhere that there is a mixture of self-closed components ending with a space before `/>` (this file) and some without the space (the server file). 

I did this edit on Github so I'm not sure if the lint config specifies that or not.
