### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/Guides/OpenShift_Deployment.md
+++ b/Guides/OpenShift_Deployment.md
@@ -1,4 +1,4 @@
-#OpenShift Deployment Guide
+# OpenShift Deployment Guide
 
 **IMPORTANT:** First of all, you **MUST** check and set the `host` settings in the config file `./src/config`
 You should see this:

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ This repo was inspired by the following projects and their authors
 * [hapi-socketio-redis-chat-example](https://github.com/dwyl/hapi-socketio-redis-chat-example) by [dwyl](https://github.com/dwyl)
 * Scaling Redis/Socketio [redispubsub](https://github.com/rajaraodv/redispubsub)
 
-##Features
+## Features
 * Hapi server framework for Node. - [hapijs](https://github.com/hapijs/hapi)
 * React JS Library for user interfaces. - [reactjs](https://github.com/reactjs)
 * Webpack + [React-transform](https://github.com/gaearon/babel-plugin-react-transform) and [react-transform-hmr](https://github.com/gaearon/react-transform-hmr)
@@ -125,7 +125,7 @@ Tests are incomplete.
 
 [OpenShift Deployment](https://github.com/Dindaleon/hapi-react-starter-kit/blob/master/Guides/OpenShift_Deployment.md)
 
-##Todo
+## Todo
 * [ ] testing, testing, testing...
 * [x] improve redux implementation
 * [x] Testing


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
